### PR TITLE
Drop requirement on "pygame"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 dependencies = [
     "numpy",
-    "pygame",
     "PyOpenGL",
 ]
 [build-system]


### PR DESCRIPTION
Right now, installing this forces an install of pygame/pygame, which is not ideal for users of pygame-ce. Dropping the requirement solves this.

Users of pygame-shaders will almost certainly already have a pygame installed when they want to install this package, so no harm in dropping the explicit dependency.

