### PR TITLE
fix shader output alpha & set_target_surface

### DIFF
--- a/pygame_shaders/pygame_shaders.py
+++ b/pygame_shaders/pygame_shaders.py
@@ -101,7 +101,10 @@ class Shader:
 
         # self.screen_texture.texture.release()
         self.target_surface = surface
-        # self.screen_texture = texture.Texture(pygame.Surface(self.target_surface.get_size()), self.ctx)
+        self.render_rect = screen_rect.ScreenRect(self.target_surface.get_size(),self.target_surface.get_size(), (0, 0), self.ctx, self.shader)
+        
+        self.screen_texture = texture.Texture(pygame.Surface(self.target_surface.get_size()), self.ctx)
+        self.framebuffer = self.ctx.simple_framebuffer(size=self.target_surface.get_size(), components=4)
 
     def set_target_texture(self, texture: texture.Texture) -> None:
         """
@@ -157,8 +160,13 @@ class Shader:
         with self.scope:
             self.framebuffer.use()
             self.render_rect.vao.render()
-            surf = pygame.image.frombuffer(self.framebuffer.read(), self.target_surface.get_size(), "RGB")
+            surf = pygame.image.frombuffer(
+                self.framebuffer.read(components=4, alignment=1),
+                self.target_surface.get_size(),
+                "RGBA"
+            )
         return pygame.transform.flip(surf, False, True)
+
 
 class ComputeShader:
     """


### PR DESCRIPTION
i dont know why the alpha thing is still an issue lol

set_target_surface wouldnt refresh all the target_surface dependent values leading to a crash when it tried to get buffer size or something like that and it wouldnt match what it expected it to be