### PR TITLE
fixed pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
-dependencies = [
-    "numpy",
-    "moderngl",
-]
+[project]
+name = "pygame_shaders"
+version = "2.0.1"
+dependencies = ["numpy", "moderngl", "pygame"]
+dynamic = ["description", "readme", "authors", "classifiers"]
+
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel"
+    "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pygame_shaders
-version = 2.0.0
+version = 2.0.1
 author = ScriptLine Studios
 author_email = scriptlinestudios@protonmail.com
 description = a library to easily integrate shaders into your new or existing pygame projects 


### PR DESCRIPTION
Formerly when running pip install on the repository it would install pygame-shaders without the necessary dependencies, meaning it wouldn't work out of the box.

I just made it so that pip install would also install dependencies, pygame, numpy, and moderngl